### PR TITLE
Add DictionaryJsonConverter to properly deserialize for Content.ToolUseInput

### DIFF
--- a/src/Claudia/DictionaryJsonConverter.cs
+++ b/src/Claudia/DictionaryJsonConverter.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Claudia;
+
+public class DictionaryJsonConverter : JsonConverter<Dictionary<string, string>>
+{
+    public override Dictionary<string, string> Read(ref Utf8JsonReader reader, Type _, JsonSerializerOptions __)
+    {
+        var dictionary = new Dictionary<string, string>();
+
+        while (reader.Read())
+        {
+            if (reader.TokenType == JsonTokenType.PropertyName)
+            {
+                var key = Encoding.UTF8.GetString(reader.ValueSpan);
+                reader.Read();
+                var value = Encoding.UTF8.GetString(reader.ValueSpan);
+                dictionary[key] = value;
+            }
+            else if (reader.TokenType == JsonTokenType.EndObject)
+            {
+                break;
+            }
+        }
+
+        return dictionary;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Dictionary<string, string> value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, options);
+    }
+}

--- a/src/Claudia/MessageRequest.cs
+++ b/src/Claudia/MessageRequest.cs
@@ -163,6 +163,7 @@ public record class Content
 
     /// <summary>An object containing the input being passed to the tool, conforming to the tool's input_schema.</summary>
     [JsonPropertyName("input")]
+    [JsonConverter(typeof(DictionaryJsonConverter))]
     public Dictionary<string, string>? ToolUseInput { get; set; }
 
     /// <summary>The result of the tool.</summary>


### PR DESCRIPTION
# Summary
* Proposal to fix #18 

# Changes
* Add `DictionaryJsonConverter` to properly deserialize for Content.ToolUseInput
* Specify [JsonConverter(typeof(DictionaryJsonConverter))] attribute for Content.ToolUseInput