### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,7 +14,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Icon.png</PackageIcon>
     <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../opensource.snk</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     <!-- For BenchmarkDotNet generated project-->
     <AssemblyOriginatorKeyFile Condition="EXISTS('./../../../../../../opensource.snk')">../../../../../../opensource.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -19,7 +20,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 
 </Project>

--- a/sandbox/BedrockBlazorApp1/BedrockBlazorApp1.csproj
+++ b/sandbox/BedrockBlazorApp1/BedrockBlazorApp1.csproj
@@ -4,7 +4,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
-		<IsPackable>false</IsPackable>
 		<UserSecretsId>ce2f09c8-e783-4af2-b9f1-8226c422040c</UserSecretsId>
 	</PropertyGroup>
 

--- a/sandbox/BedrockConsoleApp/BedrockConsoleApp.csproj
+++ b/sandbox/BedrockConsoleApp/BedrockConsoleApp.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/sandbox/BlazorApp1/BlazorApp1.csproj
+++ b/sandbox/BlazorApp1/BlazorApp1.csproj
@@ -5,7 +5,6 @@
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>48f52524-9f77-4194-bc43-b7e749c8e706</UserSecretsId>
-		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/sandbox/ConsoleApp1/ConsoleApp1.csproj
+++ b/sandbox/ConsoleApp1/ConsoleApp1.csproj
@@ -5,7 +5,6 @@
 		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
 		<NoWarn>1591</NoWarn>
 		<GenerateDocumentationFile>false</GenerateDocumentationFile>
 	</PropertyGroup>

--- a/src/Claudia.Bedrock/Claudia.Bedrock.csproj
+++ b/src/Claudia.Bedrock/Claudia.Bedrock.csproj
@@ -10,15 +10,13 @@
 		<NoWarn>1701;1702;1591;1573</NoWarn>
 
 		<!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
 		<PackageTags>ai;</PackageTags>
 		<Description>AWS Bedrock support for Claudia.</Description>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-		<EmbeddedResource Include="..\..\LICENSE" />
-
 		<PackageReference Include="AWSSDK.BedrockRuntime" Version="3.7.301.47" />
 	</ItemGroup>
 

--- a/src/Claudia/Claudia.csproj
+++ b/src/Claudia/Claudia.csproj
@@ -9,14 +9,13 @@
 		<NoWarn>1701;1702;1591;1573</NoWarn>
 
 		<!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
 		<PackageTags>ai;</PackageTags>
 		<Description>Unofficial Anthropic Claude API client for .NET.</Description>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\Icon.png" Pack="true" PackagePath="/" />
-		<EmbeddedResource Include="..\..\LICENSE" />
 		<InternalsVisibleTo Include="Claudia.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001000144ec28f1e9ef7b17dacc47425a7a153aea0a7baa590743a2d1a86f4b3e10a8a12712c6e647966bfd8bd6e830048b23bd42bbc56f179585c15b8c19cf86c0eed1b73c993dd7a93a30051dd50fdda0e4d6b65e6874e30f1c37cf8bcbc7fe02c7f2e6a0a3327c0ccc1631bf645f40732521fa0b41a30c178d08f7dd779d42a1ee" />
 
 		<!-- Bundle SourceGenerator -->

--- a/tests/Claudia.FunctionGenerator.Tests/Claudia.FunctionGenerator.Tests.csproj
+++ b/tests/Claudia.FunctionGenerator.Tests/Claudia.FunctionGenerator.Tests.csproj
@@ -5,7 +5,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>9113</NoWarn>
 	</PropertyGroup>

--- a/tests/Claudia.Tests/Claudia.Tests.csproj
+++ b/tests/Claudia.Tests/Claudia.Tests.csproj
@@ -5,7 +5,6 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 
-		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>9113</NoWarn>
 	</PropertyGroup>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
