### PR TITLE
ci: add id-token: write for NuGet Trusted Publish

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -36,9 +36,10 @@ jobs:
     needs: [build-dotnet]
     permissions:
       contents: write
+      id-token: write # required for NuGet Trusted Publish
     uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
     with:
-      commit-id: ''
+      commit-id: ""
       dry-run: ${{ inputs.dry-run }}
       tag: ${{ inputs.tag }}
       nuget-push: true


### PR DESCRIPTION
## Summary

This PR enables `build-release.yaml` to publish NuGet packages via [NuGet Trusted Publish](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/). 
This means we no longer depend on a Personal Access Token (PAT) to publish .nupkg packages.